### PR TITLE
282 create external api postdelete for patients

### DIFF
--- a/src/main/java/ch/uzh/ifi/imrg/patientapp/coachapi/CoachPatientController.java
+++ b/src/main/java/ch/uzh/ifi/imrg/patientapp/coachapi/CoachPatientController.java
@@ -38,4 +38,11 @@ public class CoachPatientController {
         JwtUtil.removeJwtCookie(httpServletResponse);
         return PatientMapper.INSTANCE.convertEntityToPatientOutputDTO(createdPatient);
     }
+
+    @DeleteMapping("coach/patients/{patientId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @SecurityRequirement(name = "X-Coach-Key")
+    public void deletePatient(@PathVariable String patientId) {
+        patientService.removePatient(patientId);
+    }
 }

--- a/src/main/java/ch/uzh/ifi/imrg/patientapp/entity/JournalEntry.java
+++ b/src/main/java/ch/uzh/ifi/imrg/patientapp/entity/JournalEntry.java
@@ -1,6 +1,6 @@
 package ch.uzh.ifi.imrg.patientapp.entity;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -28,11 +28,11 @@ public class JournalEntry {
 
     @Column(name = "created_at", updatable = false)
     @CreationTimestamp
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @Column(name = "updated_at")
     @UpdateTimestamp
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     @Column(nullable = false)
     private String title;

--- a/src/main/java/ch/uzh/ifi/imrg/patientapp/entity/Meeting.java
+++ b/src/main/java/ch/uzh/ifi/imrg/patientapp/entity/Meeting.java
@@ -1,7 +1,7 @@
 package ch.uzh.ifi.imrg.patientapp.entity;
 
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
+import java.time.Instant;
+
 import java.util.UUID;
 
 import org.hibernate.annotations.CreationTimestamp;
@@ -27,21 +27,21 @@ public class Meeting {
 
     @Column(name = "created_at", updatable = false)
     @CreationTimestamp
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @Column(name = "updated_at")
     @UpdateTimestamp
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "patient_id")
     private Patient patient;
 
     @Column(name = "start_at", nullable = false)
-    private OffsetDateTime startAt;
+    private Instant startAt;
 
     @Column(name = "end_at", nullable = false)
-    private OffsetDateTime endAt;
+    private Instant endAt;
 
     @Column(nullable = true)
     private String location;

--- a/src/main/java/ch/uzh/ifi/imrg/patientapp/entity/Patient.java
+++ b/src/main/java/ch/uzh/ifi/imrg/patientapp/entity/Patient.java
@@ -68,8 +68,14 @@ public class Patient implements Serializable {
     @OneToMany(mappedBy = "patient", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Conversation> conversations;
 
-    @OneToMany(mappedBy = "patient", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "patient", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Exercise> exercises;
+
+    @OneToMany(mappedBy = "patient", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Meeting> meetings;
+
+    @OneToMany(mappedBy = "patient", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<JournalEntry> journalEntries;
 
     @Column(name = "coach_access_key", nullable = false)
     private String coachAccessKey;

--- a/src/main/java/ch/uzh/ifi/imrg/patientapp/entity/Patient.java
+++ b/src/main/java/ch/uzh/ifi/imrg/patientapp/entity/Patient.java
@@ -64,7 +64,7 @@ public class Patient implements Serializable {
     @Column(name = "private_key", unique = true)
     private String privateKey;
 
-    @OneToMany(mappedBy = "patient", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "patient", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Conversation> conversations;
 
     @Column(name = "coach_access_key", nullable = false)

--- a/src/main/java/ch/uzh/ifi/imrg/patientapp/repository/MeetingRepository.java
+++ b/src/main/java/ch/uzh/ifi/imrg/patientapp/repository/MeetingRepository.java
@@ -1,6 +1,7 @@
 package ch.uzh.ifi.imrg.patientapp.repository;
 
-import java.time.OffsetDateTime;
+import java.time.Instant;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -18,6 +19,6 @@ public interface MeetingRepository extends JpaRepository<Meeting, String> {
 
     List<Meeting> findByPatientId(String patientId);
 
-    List<Meeting> findByPatientIdAndStartAtAfter(String patientId, OffsetDateTime from);
+    List<Meeting> findByPatientIdAndStartAtAfter(String patientId, Instant from);
 
 }

--- a/src/main/java/ch/uzh/ifi/imrg/patientapp/rest/dto/input/CreateMeetingDTO.java
+++ b/src/main/java/ch/uzh/ifi/imrg/patientapp/rest/dto/input/CreateMeetingDTO.java
@@ -1,6 +1,6 @@
 package ch.uzh.ifi.imrg.patientapp.rest.dto.input;
 
-import java.time.OffsetDateTime;
+import java.time.Instant;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -14,9 +14,9 @@ public class CreateMeetingDTO {
     // this is not needed, becaus patientId comes from path variable
     // private String patientId;
 
-    private OffsetDateTime startAt;
+    private Instant startAt;
 
-    private OffsetDateTime endAt;
+    private Instant endAt;
 
     private String location;
 

--- a/src/main/java/ch/uzh/ifi/imrg/patientapp/rest/dto/input/UpdateMeetingDTO.java
+++ b/src/main/java/ch/uzh/ifi/imrg/patientapp/rest/dto/input/UpdateMeetingDTO.java
@@ -3,7 +3,7 @@ package ch.uzh.ifi.imrg.patientapp.rest.dto.input;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.OffsetDateTime;
+import java.time.Instant;
 
 import ch.uzh.ifi.imrg.patientapp.constant.MeetingStatus;
 
@@ -11,9 +11,9 @@ import ch.uzh.ifi.imrg.patientapp.constant.MeetingStatus;
 @Setter
 public class UpdateMeetingDTO {
 
-    private OffsetDateTime startAt;
+    private Instant startAt;
 
-    private OffsetDateTime endAt;
+    private Instant endAt;
 
     private String location;
 

--- a/src/main/java/ch/uzh/ifi/imrg/patientapp/rest/dto/output/GetAllJournalEntriesDTO.java
+++ b/src/main/java/ch/uzh/ifi/imrg/patientapp/rest/dto/output/GetAllJournalEntriesDTO.java
@@ -1,6 +1,6 @@
 package ch.uzh.ifi.imrg.patientapp.rest.dto.output;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Set;
 
 import lombok.Getter;
@@ -11,8 +11,8 @@ import lombok.Setter;
 public class GetAllJournalEntriesDTO {
 
     private String id;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    private Instant createdAt;
+    private Instant updatedAt;
     private String title;
     private Set<String> tags;
     private boolean sharedWithTherapist;

--- a/src/main/java/ch/uzh/ifi/imrg/patientapp/rest/dto/output/JournalEntryOutputDTO.java
+++ b/src/main/java/ch/uzh/ifi/imrg/patientapp/rest/dto/output/JournalEntryOutputDTO.java
@@ -1,6 +1,6 @@
 package ch.uzh.ifi.imrg.patientapp.rest.dto.output;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Set;
 
 import lombok.Getter;
@@ -11,8 +11,8 @@ import lombok.Setter;
 public class JournalEntryOutputDTO {
 
     private String id;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    private Instant createdAt;
+    private Instant updatedAt;
     private String title;
     private String content;
     private Set<String> tags;

--- a/src/main/java/ch/uzh/ifi/imrg/patientapp/rest/dto/output/MeetingOutputDTO.java
+++ b/src/main/java/ch/uzh/ifi/imrg/patientapp/rest/dto/output/MeetingOutputDTO.java
@@ -1,7 +1,6 @@
 package ch.uzh.ifi.imrg.patientapp.rest.dto.output;
 
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
+import java.time.Instant;
 
 import ch.uzh.ifi.imrg.patientapp.constant.MeetingStatus;
 import lombok.Getter;
@@ -15,15 +14,15 @@ public class MeetingOutputDTO {
 
     private String externalMeetingId;
 
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     private String patientId;
 
-    private OffsetDateTime startAt;
+    private Instant startAt;
 
-    private OffsetDateTime endAt;
+    private Instant endAt;
 
     private String location;
 

--- a/src/main/java/ch/uzh/ifi/imrg/patientapp/service/MessageService.java
+++ b/src/main/java/ch/uzh/ifi/imrg/patientapp/service/MessageService.java
@@ -1,6 +1,5 @@
 package ch.uzh.ifi.imrg.patientapp.service;
 
-
 import ch.uzh.ifi.imrg.patientapp.entity.Conversation;
 import ch.uzh.ifi.imrg.patientapp.entity.Message;
 import ch.uzh.ifi.imrg.patientapp.entity.Patient;
@@ -12,13 +11,10 @@ import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-import java.nio.file.AccessDeniedException;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
 
 @Service
 @Transactional
@@ -59,19 +55,21 @@ public class MessageService {
         return priorMessages;
     }
 
-
     public Message generateAnswer(Patient patient, String externalConversationId, String message) {
 
-        Optional<Conversation> optionalConversation = conversationRepository.getConversationByExternalId(externalConversationId);
-        Conversation conversation = optionalConversation.orElseThrow(() -> new IllegalArgumentException("Conversation not found"));
-        authorizationService.checkConversationAccess(conversation,patient, "You are trying to send a message to another persons chat.");
+        Optional<Conversation> optionalConversation = conversationRepository
+                .getConversationByExternalId(externalConversationId);
+        Conversation conversation = optionalConversation
+                .orElseThrow(() -> new IllegalArgumentException("Conversation not found"));
+        authorizationService.checkConversationAccess(conversation, patient,
+                "You are trying to send a message to another persons chat.");
         String key = CryptographyUtil.decrypt(patient.getPrivateKey());
         // Make message persistent
         Message newMessage = new Message();
         newMessage.setRequest(CryptographyUtil.encrypt(message, key));
 
-        List<Map<String, String>> priorMessages = parseMessagesFromConversation(conversation,key);
-        String answer = promptBuilderService.getResponse(patient.isAdmin(),priorMessages, message);
+        List<Map<String, String>> priorMessages = parseMessagesFromConversation(conversation, key);
+        String answer = promptBuilderService.getResponse(patient.isAdmin(), priorMessages, message);
 
         newMessage.setResponse(CryptographyUtil.encrypt(answer, key));
         newMessage.setConversation(conversation);

--- a/src/main/java/ch/uzh/ifi/imrg/patientapp/service/PatientService.java
+++ b/src/main/java/ch/uzh/ifi/imrg/patientapp/service/PatientService.java
@@ -14,6 +14,7 @@ import ch.uzh.ifi.imrg.patientapp.rest.dto.input.ChangePasswordDTO;
 import ch.uzh.ifi.imrg.patientapp.rest.dto.input.LoginPatientDTO;
 import ch.uzh.ifi.imrg.patientapp.utils.JwtUtil;
 import ch.uzh.ifi.imrg.patientapp.utils.PasswordUtil;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -118,6 +119,13 @@ public class PatientService {
         loggedInPatient.setPassword(PasswordUtil.encryptPassword(changePasswordDTO.getNewPassword()));
         patientRepository.save(loggedInPatient);
 
+    }
+
+    public void removePatient(String patientId) {
+        if (!patientRepository.existsById(patientId)) {
+            throw new EntityNotFoundException("Patient " + patientId + " not found");
+        }
+        patientRepository.deleteById(patientId);
     }
 
 }

--- a/src/test/java/ch/uzh/ifi/imrg/patientapp/controller/CoachMeetingControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/imrg/patientapp/controller/CoachMeetingControllerTest.java
@@ -14,8 +14,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
+
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
@@ -67,8 +67,8 @@ public class CoachMeetingControllerTest {
                 String patientId = "p1";
                 CreateMeetingDTO dto = new CreateMeetingDTO();
                 dto.setExternalMeetingId("ext1");
-                dto.setStartAt(OffsetDateTime.parse("2025-06-15T10:00:00Z"));
-                dto.setEndAt(OffsetDateTime.parse("2025-06-15T11:00:00Z"));
+                dto.setStartAt(Instant.parse("2025-06-15T10:00:00Z"));
+                dto.setEndAt(Instant.parse("2025-06-15T11:00:00Z"));
                 dto.setLocation("Room 101");
 
                 Meeting saved = new Meeting();
@@ -78,7 +78,7 @@ public class CoachMeetingControllerTest {
                 saved.setEndAt(dto.getEndAt());
                 saved.setLocation("Room 101");
                 saved.setMeetingStatus(MeetingStatus.PENDING);
-                saved.setCreatedAt(LocalDateTime.parse("2025-06-15T09:00:00"));
+                saved.setCreatedAt(Instant.parse("2025-06-15T09:00:00"));
                 Patient patient = new Patient();
                 patient.setId(patientId);
                 saved.setPatient(patient);
@@ -139,8 +139,8 @@ public class CoachMeetingControllerTest {
                 String patientId = "p1";
                 String meetingId = "m1";
                 UpdateMeetingDTO dto = new UpdateMeetingDTO();
-                dto.setStartAt(OffsetDateTime.parse("2025-06-15T12:00:00Z"));
-                dto.setEndAt(OffsetDateTime.parse("2025-06-15T13:00:00Z"));
+                dto.setStartAt(Instant.parse("2025-06-15T12:00:00Z"));
+                dto.setEndAt(Instant.parse("2025-06-15T13:00:00Z"));
                 dto.setLocation("Room 103");
                 dto.setMeetingStatus(MeetingStatus.CONFIRMED);
 
@@ -151,7 +151,7 @@ public class CoachMeetingControllerTest {
                 updated.setEndAt(dto.getEndAt());
                 updated.setLocation("Room 103");
                 updated.setMeetingStatus(MeetingStatus.CONFIRMED);
-                updated.setCreatedAt(LocalDateTime.parse("2025-06-15T09:00:00"));
+                updated.setCreatedAt(Instant.parse("2025-06-15T09:00:00"));
 
                 when(meetingService.updateMeeting(eq(patientId), eq(meetingId), any(UpdateMeetingDTO.class)))
                                 .thenReturn(updated);

--- a/src/test/java/ch/uzh/ifi/imrg/patientapp/controller/JournalEntryControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/imrg/patientapp/controller/JournalEntryControllerTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
@@ -88,8 +88,8 @@ public class JournalEntryControllerTest {
                 outDto.setTags(Set.of("tag1", "tag2"));
                 outDto.setSharedWithTherapist(true);
                 outDto.setAiAccessAllowed(false);
-                outDto.setCreatedAt(LocalDateTime.of(2025, 6, 20, 12, 0));
-                outDto.setUpdatedAt(LocalDateTime.of(2025, 6, 20, 12, 0));
+                outDto.setCreatedAt(Instant.parse("2025-06-26T10:15:30+02:00"));
+                outDto.setUpdatedAt(Instant.parse("2025-06-26T10:15:30+02:00"));
 
                 when(journalEntryService.createEntry(any(JournalEntryRequestDTO.class), any(Patient.class)))
                                 .thenReturn(outDto);
@@ -131,8 +131,8 @@ public class JournalEntryControllerTest {
                 m1.setId("e1");
                 m1.setTitle("T1");
                 m1.setTags(Set.of("t1"));
-                m1.setCreatedAt(LocalDateTime.of(2025, 6, 1, 10, 0));
-                m1.setUpdatedAt(LocalDateTime.of(2025, 6, 1, 10, 0));
+                m1.setCreatedAt(Instant.parse("2025-06-26T10:15:30+02:00"));
+                m1.setUpdatedAt(Instant.parse("2025-06-26T10:15:30+02:00"));
 
                 when(journalEntryService.listEntries(mockPatient)).thenReturn(List.of(m1));
 
@@ -156,8 +156,8 @@ public class JournalEntryControllerTest {
                 outDto.setTags(Set.of("x", "y"));
                 outDto.setSharedWithTherapist(false);
                 outDto.setAiAccessAllowed(true);
-                outDto.setCreatedAt(LocalDateTime.of(2025, 6, 2, 11, 0));
-                outDto.setUpdatedAt(LocalDateTime.of(2025, 6, 2, 11, 0));
+                outDto.setCreatedAt(Instant.parse("2025-06-26T10:15:30+02:00"));
+                outDto.setUpdatedAt(Instant.parse("2025-06-26T10:15:30+02:00"));
 
                 when(journalEntryService.getEntry(mockPatient, "e2")).thenReturn(outDto);
 
@@ -188,8 +188,8 @@ public class JournalEntryControllerTest {
                 outDto.setTags(Set.of("a", "b"));
                 outDto.setSharedWithTherapist(false);
                 outDto.setAiAccessAllowed(true);
-                outDto.setCreatedAt(LocalDateTime.of(2025, 6, 3, 12, 0));
-                outDto.setUpdatedAt(LocalDateTime.of(2025, 6, 3, 12, 0));
+                outDto.setCreatedAt(Instant.parse("2025-06-26T10:15:30+02:00"));
+                outDto.setUpdatedAt(Instant.parse("2025-06-26T10:15:30+02:00"));
 
                 when(journalEntryService.updateJournalEntry(any(Patient.class), eq("e3"),
                                 any(JournalEntryRequestDTO.class)))

--- a/src/test/java/ch/uzh/ifi/imrg/patientapp/repository/PatientRepositoryCascadeTest.java
+++ b/src/test/java/ch/uzh/ifi/imrg/patientapp/repository/PatientRepositoryCascadeTest.java
@@ -1,0 +1,159 @@
+package ch.uzh.ifi.imrg.patientapp.repository;
+
+import org.springframework.test.context.ActiveProfiles;
+
+import ch.uzh.ifi.imrg.patientapp.entity.Conversation;
+import ch.uzh.ifi.imrg.patientapp.entity.JournalEntry;
+import ch.uzh.ifi.imrg.patientapp.entity.Meeting;
+import ch.uzh.ifi.imrg.patientapp.entity.Patient;
+import ch.uzh.ifi.imrg.patientapp.entity.Exercise.Exercise;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.OffsetDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@ActiveProfiles("test")
+@DataJpaTest
+public class PatientRepositoryCascadeTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private PatientRepository patientRepository;
+
+    @Autowired
+    private ExerciseRepository exerciseRepository;
+
+    @Autowired
+    private ConversationRepository conversationRepository;
+
+    @Autowired
+    private JournalEntryRepository journalEntryRepository;
+
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @Test
+    void deletingPatientAlsoDeletesExcercise() {
+        Patient patient = new Patient();
+        patient.setId("Id1");
+        patient.setEmail("test@gg.com");
+        patient.setPassword("savePW");
+        patient.setCoachAccessKey("saveKey");
+        patient = patientRepository.saveAndFlush(patient);
+
+        Exercise exercise = new Exercise();
+        exercise.setId("exId");
+        exercise.setPatient(patient);
+        exerciseRepository.saveAndFlush(exercise);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(patientRepository.existsById(patient.getId()));
+        assertThat(exerciseRepository.existsById(exercise.getId()));
+
+        patientRepository.deleteById(patient.getId());
+        patientRepository.flush();
+
+        assertThat(patientRepository.existsById(patient.getId())).isFalse();
+        assertThat(exerciseRepository.existsById(exercise.getId())).isFalse();
+
+    }
+
+    @Test
+    void deletingPatientAlsoDeletesConversation() {
+        Patient patient = new Patient();
+        patient.setId("Id1");
+        patient.setEmail("test@gg.com");
+        patient.setPassword("savePW");
+        patient.setCoachAccessKey("saveKey");
+        patient = patientRepository.saveAndFlush(patient);
+
+        Conversation conversation = new Conversation();
+        conversation.setId("convoId");
+        conversation.setExternalId("exId");
+        conversation.setPatient(patient);
+        conversationRepository.saveAndFlush(conversation);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(patientRepository.existsById(patient.getId()));
+        assertThat(conversationRepository.existsById(conversation.getId()));
+
+        patientRepository.deleteById(patient.getId());
+        patientRepository.flush();
+
+        assertThat(patientRepository.existsById(patient.getId())).isFalse();
+        assertThat(conversationRepository.existsById(conversation.getId())).isFalse();
+
+    }
+
+    @Test
+    void deletingPatientAlsoDeletesJournalEntry() {
+        Patient patient = new Patient();
+        patient.setId("Id1");
+        patient.setEmail("test@gg.com");
+        patient.setPassword("savePW");
+        patient.setCoachAccessKey("saveKey");
+        patient = patientRepository.saveAndFlush(patient);
+
+        JournalEntry journalEntry = new JournalEntry();
+        journalEntry.setId("jeId");
+        journalEntry.setPatient(patient);
+        journalEntry.setTitle("title");
+        journalEntryRepository.saveAndFlush(journalEntry);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(patientRepository.existsById(patient.getId()));
+        assertThat(journalEntryRepository.existsById(journalEntry.getId()));
+
+        patientRepository.deleteById(patient.getId());
+        patientRepository.flush();
+
+        assertThat(patientRepository.existsById(patient.getId())).isFalse();
+        assertThat(journalEntryRepository.existsById(journalEntry.getId())).isFalse();
+
+    }
+
+    @Test
+    void deletingPatientAlsoDeletesMeeting() {
+        Patient patient = new Patient();
+        patient.setId("Id1");
+        patient.setEmail("test@gg.com");
+        patient.setPassword("savePW");
+        patient.setCoachAccessKey("saveKey");
+        patient = patientRepository.saveAndFlush(patient);
+
+        Meeting meeting = new Meeting();
+        meeting.setId("MeetId");
+        meeting.setExternalMeetingId("exId");
+        meeting.setStartAt(OffsetDateTime.parse("2025-06-26T10:15:30+02:00"));
+        meeting.setEndAt(OffsetDateTime.parse("2025-06-26T11:45:15.500+02:00"));
+        meeting.setPatient(patient);
+        meetingRepository.saveAndFlush(meeting);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(patientRepository.existsById(patient.getId()));
+        assertThat(meetingRepository.existsById(meeting.getId()));
+
+        patientRepository.deleteById(patient.getId());
+        patientRepository.flush();
+
+        assertThat(patientRepository.existsById(patient.getId())).isFalse();
+        assertThat(meetingRepository.existsById(meeting.getId())).isFalse();
+
+    }
+}

--- a/src/test/java/ch/uzh/ifi/imrg/patientapp/repository/PatientRepositoryCascadeTest.java
+++ b/src/test/java/ch/uzh/ifi/imrg/patientapp/repository/PatientRepositoryCascadeTest.java
@@ -10,9 +10,8 @@ import ch.uzh.ifi.imrg.patientapp.entity.Exercise.Exercise;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.OffsetDateTime;
+import java.time.Instant;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -138,8 +137,8 @@ public class PatientRepositoryCascadeTest {
         Meeting meeting = new Meeting();
         meeting.setId("MeetId");
         meeting.setExternalMeetingId("exId");
-        meeting.setStartAt(OffsetDateTime.parse("2025-06-26T10:15:30+02:00"));
-        meeting.setEndAt(OffsetDateTime.parse("2025-06-26T11:45:15.500+02:00"));
+        meeting.setStartAt(Instant.parse("2025-06-26T10:15:30+02:00"));
+        meeting.setEndAt(Instant.parse("2025-06-26T11:45:15.500+02:00"));
         meeting.setPatient(patient);
         meetingRepository.saveAndFlush(meeting);
 

--- a/src/test/java/ch/uzh/ifi/imrg/patientapp/service/JournalEntryServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/imrg/patientapp/service/JournalEntryServiceTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.*;
 
 import ch.uzh.ifi.imrg.patientapp.entity.JournalEntry;
@@ -32,14 +32,12 @@ public class JournalEntryServiceTest {
     private JournalEntryService service;
 
     private Patient patient;
-    private LocalDateTime now;
 
     @BeforeEach
     void setUp() {
         patient = new Patient();
         patient.setId("p1");
         patient.setPrivateKey("encKey");
-        now = LocalDateTime.of(2025, 6, 20, 15, 30);
     }
 
     @Test
@@ -60,8 +58,6 @@ public class JournalEntryServiceTest {
         savedEntity.setTags(dto.getTags());
         savedEntity.setSharedWithTherapist(true);
         savedEntity.setAiAccessAllowed(false);
-        savedEntity.setCreatedAt(now);
-        savedEntity.setUpdatedAt(now);
 
         when(repo.saveAndFlush(any(JournalEntry.class))).thenReturn(savedEntity);
 
@@ -85,8 +81,6 @@ public class JournalEntryServiceTest {
             assertEquals(dto.getTags(), out.getTags());
             assertTrue(out.isSharedWithTherapist());
             assertFalse(out.isAiAccessAllowed());
-            assertEquals(now, out.getCreatedAt());
-            assertEquals(now, out.getUpdatedAt());
         }
     }
 
@@ -117,8 +111,6 @@ public class JournalEntryServiceTest {
         entry.setPatient(patient);
         entry.setTitle("encTitle");
         entry.setTags(Set.of("encTag"));
-        entry.setCreatedAt(now);
-        entry.setUpdatedAt(now);
         when(repo.findByPatientId("p1")).thenReturn(List.of(entry));
 
         try (MockedStatic<CryptographyUtil> crypto = mockStatic(CryptographyUtil.class)) {
@@ -135,8 +127,6 @@ public class JournalEntryServiceTest {
             assertEquals("e2", dto.getId());
             assertEquals("Title", dto.getTitle());
             assertEquals(Set.of("Tag"), dto.getTags());
-            assertEquals(now, dto.getCreatedAt());
-            assertEquals(now, dto.getUpdatedAt());
         }
     }
 
@@ -149,8 +139,6 @@ public class JournalEntryServiceTest {
         entry.setTitle("encT");
         entry.setContent("encC");
         entry.setTags(Set.of("encX"));
-        entry.setCreatedAt(now);
-        entry.setUpdatedAt(now);
         when(repo.findById("e3")).thenReturn(Optional.of(entry));
 
         try (MockedStatic<CryptographyUtil> crypto = mockStatic(CryptographyUtil.class)) {
@@ -167,8 +155,6 @@ public class JournalEntryServiceTest {
             assertEquals("T", dto.getTitle());
             assertEquals("C", dto.getContent());
             assertEquals(Set.of("X"), dto.getTags());
-            assertEquals(now, dto.getCreatedAt());
-            assertEquals(now, dto.getUpdatedAt());
         }
     }
 
@@ -202,8 +188,6 @@ public class JournalEntryServiceTest {
         updated.setTitle("encNewT");
         updated.setContent("encNewC");
         updated.setTags(Set.of("encTag1"));
-        updated.setCreatedAt(now);
-        updated.setUpdatedAt(now.plusDays(1));
         when(repo.saveAndFlush(entry)).thenReturn(updated);
 
         try (MockedStatic<CryptographyUtil> crypto = mockStatic(CryptographyUtil.class)) {
@@ -223,8 +207,6 @@ public class JournalEntryServiceTest {
             assertEquals("newT", out.getTitle());
             assertEquals("newC", out.getContent());
             assertEquals(Set.of("tag1"), out.getTags());
-            assertEquals(now, out.getCreatedAt());
-            assertEquals(now.plusDays(1), out.getUpdatedAt());
         }
     }
 

--- a/src/test/java/ch/uzh/ifi/imrg/patientapp/service/MeetingServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/imrg/patientapp/service/MeetingServiceTest.java
@@ -3,7 +3,7 @@ package ch.uzh.ifi.imrg.patientapp.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.time.OffsetDateTime;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -42,8 +42,8 @@ class MeetingServiceTest {
     void createMeeting_success() {
         CreateMeetingDTO dto = new CreateMeetingDTO();
         dto.setExternalMeetingId("ext-1");
-        dto.setStartAt(OffsetDateTime.parse("2025-06-15T10:00:00Z"));
-        dto.setEndAt(OffsetDateTime.parse("2025-06-15T11:00:00Z"));
+        dto.setStartAt(Instant.parse("2025-06-15T10:00:00Z"));
+        dto.setEndAt(Instant.parse("2025-06-15T11:00:00Z"));
         dto.setLocation("Room A");
 
         Patient patient = new Patient();


### PR DESCRIPTION
delete patient endpoint for coach
deleting a patient deletes corresponding meetings, excercises, journalEntries and conversations.
change time form OffsetDateTime and LocalDateTime to Instant